### PR TITLE
feat: Ability to (not) show vcs ignored files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -219,3 +219,19 @@ let b:select_info.godotscene.data = {"job": "rg --files --glob *.tscn"}
 let b:select_info.godotscene.sink = {"transform": {_, v -> fnameescape(v)}, "action": "GodotRun %s"}
 nnoremap <buffer> <leader><leader>f :Select godotscene<CR>
 ------------------------------------------------------------------------------
+
+== Provided APIs
+
+=== Respect VCS Ignore
+
+By default, when selecting a project file (`:Select projectfile`), it does not
+ignore the files that are ignored by your VCS (eg: `.gitignore` when talking
+about git). This is intended behaviour, but you can opt out it with:
+
+
+[source,vim]
+------------------------------------------------------------------------------
+let g:select_no_ignore_vcs = 0
+------------------------------------------------------------------------------
+
+NOTE: This can only be done when using `fd` or `rg` as they provide a way of ignoring files.

--- a/README.adoc
+++ b/README.adoc
@@ -219,19 +219,3 @@ let b:select_info.godotscene.data = {"job": "rg --files --glob *.tscn"}
 let b:select_info.godotscene.sink = {"transform": {_, v -> fnameescape(v)}, "action": "GodotRun %s"}
 nnoremap <buffer> <leader><leader>f :Select godotscene<CR>
 ------------------------------------------------------------------------------
-
-== Provided APIs
-
-=== Respect VCS Ignore
-
-By default, when selecting a project file (`:Select projectfile`), it does not
-ignore the files that are ignored by your VCS (eg: `.gitignore` when talking
-about git). This is intended behaviour, but you can opt out it with:
-
-
-[source,vim]
-------------------------------------------------------------------------------
-let g:select_no_ignore_vcs = 0
-------------------------------------------------------------------------------
-
-NOTE: This can only be done when using `fd` or `rg` as they provide a way of ignoring files.

--- a/autoload/select/def.vim
+++ b/autoload/select/def.vim
@@ -35,9 +35,17 @@ let s:select.file.prompt = "File> "
 """
 let s:select.projectfile = {}
 if executable('fd')
-    let s:select.projectfile.data = {"job": "fd --path-separator / --type f --hidden --follow --no-ignore-vcs --exclude .git"}
+    let select_string = "fd --path-separator / --type f --hidden --follow --exclude .git"
+    if exists("g:select_no_ignore_vcs")
+        let select_string .= " --no-ignore-vcs"
+    endif
+    let s:select.projectfile.data = {"job": select_string}
 elseif executable('rg')
-    let s:select.projectfile.data = {"job": "rg --path-separator / --files --no-ignore-vcs --hidden --glob !.git"}
+    let select_string = "rg --path-separator / --files --hidden --glob !.git"
+    if exists("g:select_no_ignore_vcs")
+        let select_string .= " --no-ignore-vcs"
+    endif
+    let s:select.projectfile.data = {"job": select_string}
 elseif !has("win32")
     let s:select.projectfile.data = {"job": "find -type f -not -path \"*/.git/*\""}
 else

--- a/autoload/select/def.vim
+++ b/autoload/select/def.vim
@@ -34,18 +34,15 @@ let s:select.file.prompt = "File> "
 """ Select projectfile
 """
 let s:select.projectfile = {}
+let s:no_ignore_vcs = get(g:, "select_no_ignore_vcs", 1) ? " --no-ignore-vcs" : ""
 if executable('fd')
-    let select_string = "fd --path-separator / --type f --hidden --follow --exclude .git"
-    if exists("g:select_no_ignore_vcs")
-        let select_string .= " --no-ignore-vcs"
-    endif
-    let s:select.projectfile.data = {"job": select_string}
+    let s:select.projectfile.data = {
+                \ "job": "fd --path-separator / --type f --hidden --follow --exclude .git" .. s:no_ignore_vcs
+                \ }
 elseif executable('rg')
-    let select_string = "rg --path-separator / --files --hidden --glob !.git"
-    if exists("g:select_no_ignore_vcs")
-        let select_string .= " --no-ignore-vcs"
-    endif
-    let s:select.projectfile.data = {"job": select_string}
+    let s:select.projectfile.data = {
+                \ "job": "rg --path-separator / --files --hidden --glob !.git" .. s:no_ignore_vcs
+                \ }
 elseif !has("win32")
     let s:select.projectfile.data = {"job": "find -type f -not -path \"*/.git/*\""}
 else

--- a/doc/select.txt
+++ b/doc/select.txt
@@ -50,7 +50,14 @@ Maximum items to be collected and matched against, default 50000.
 Has effect only for data collected by jobs.
 For example, if you `:Select projectfile ~` you will only be able to select out
 of 50000 files.
+>
+    let g:select_no_ignore_vcs = 0
 
+By default, when selecting a project file (`:Select projectfile`), it does not
+ignore the files that are ignored by your VCS (eg: `.gitignore` when talking
+about git). You must opt out of this intended behaviour.
+NOTE: This can only be done when using `fd` or `rg` as they provide a way of
+ignoring files.
 
 
 MAPPINGS                                              *select-plugin-mappings*

--- a/doc/select.txt
+++ b/doc/select.txt
@@ -50,12 +50,17 @@ Maximum items to be collected and matched against, default 50000.
 Has effect only for data collected by jobs.
 For example, if you `:Select projectfile ~` you will only be able to select out
 of 50000 files.
+
+
+*g:select_no_ignore_vcs*
+
+When selecting a project file (`:Select projectfile`), it does not
+ignore the files that are ignored by your VCS (eg: `.gitignore` when talking
+about git). You must opt out of this intended behaviour, default is 1.
+
 >
     let g:select_no_ignore_vcs = 0
 
-By default, when selecting a project file (`:Select projectfile`), it does not
-ignore the files that are ignored by your VCS (eg: `.gitignore` when talking
-about git). You must opt out of this intended behaviour.
 NOTE: This can only be done when using `fd` or `rg` as they provide a way of
 ignoring files.
 


### PR DESCRIPTION
Closes #4.

By default, the `:Select projectfile` command will not show the ignored
files from your version control system, unless you explicitly change
this behaviour with `let g:select_no_ignore_vcs = 1`.