### PR TITLE
fix: support BSD find

### DIFF
--- a/autoload/select/def.vim
+++ b/autoload/select/def.vim
@@ -43,7 +43,7 @@ elseif executable('rg')
                 \ "job": "rg --path-separator / --files --hidden --glob !.git" .. s:no_ignore_vcs
                 \ }
 elseif !has("win32")
-    let s:select.projectfile.data = {"job": "find -type f -not -path \"*/.git/*\""}
+    let s:select.projectfile.data = {"job": "find -L . -name .git -prune -o -type f -print"}
 else
     let s:select.projectfile.data = ""
 endif


### PR DESCRIPTION
BSD find needs to have a directory specified and does not default to the current working directory.

Also:

- add `-L` to follow links (in spirit with how the commands `fd` and `rg` are set up).
- use `-prune` instead of `-not` as the latter will travese unwanted directories and then exclude them